### PR TITLE
Add import celery app script in __init__.py file inside config

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)


### PR DESCRIPTION
Because of omitting this script inside init file, celery was giving the error of "SSL: error:0A00006C:SSL routines::bad key share" in nginx error logs. 